### PR TITLE
Fixed phone number format issue

### DIFF
--- a/src/request_quote.html
+++ b/src/request_quote.html
@@ -61,7 +61,7 @@
             <p> 
                 <font color="black"> Phone:</font>
             </p>
-            <input type="tel" pattern="[0-9]{3}-[0-9]{2}-[0-9]{3}" style="border-color: #bfae78"name ="phone" class="form-control" id="exampleInputPassword1" placeholder="Phone Number" required>
+            <input type="tel" pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}" style="border-color: #bfae78"name ="phone" class="form-control" id="exampleInputPassword1" placeholder="Phone Number" required>
             <p>
                 <font color="black">Quantity:</font>
             </p>


### PR DESCRIPTION
The phone number field for the estimate page did not accept standard US phone numbers (9 digits inluding area code)